### PR TITLE
fix: allow for empty eventQueries array

### DIFF
--- a/visualizations/nr-area-chart/index.js
+++ b/visualizations/nr-area-chart/index.js
@@ -62,7 +62,7 @@ function LineEventChart(props) {
       queries.push({ query: newQuery, accountId, type: 'scatter' });
     });
 
-    eventQueries
+    (eventQueries || [])
       .filter(e => e.accountId && e.query && e.name)
       .forEach(q => {
         const { accountId, query, enableFilters, color, name } = q;


### PR DESCRIPTION
When eventQueries is empty the filter is erroring