### PR TITLE
feat: add configurable tile layer URL and attribution to Map widget (Leaflet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,12 @@ Click on the short description in each section to view chart details.
   - **max**: Maximum value
   - **count**: Count of data points
 
+  ##### Custom Tile Layers (Leaflet only)
+  Use a different map tile provider instead of the default OpenStreetMap tiles.
+
+  - **Map Tile Layer URL**: URL template for the map tile layer (default: `https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png`)
+  - **Map Tile Layer Attribution**: Attribution text/HTML shown for the map tile layer (default: `&copy; OpenStreetMap contributors`)
+
   ##### Weather Overlay (Leaflet only)
   Overlay real-time weather data from [OpenWeatherMap](https://openweathermap.org/) on the map. Requires a free OpenWeatherMap API key.
 

--- a/visualizations/nr-mapbox/leaflet/index.js
+++ b/visualizations/nr-mapbox/leaflet/index.js
@@ -90,8 +90,17 @@ function LeafletRoot(props) {
     hideMarkers = false,
     enableInclementWeatherEvents = false,
     weatherAlertMinSeverity = 'Minor',
-    openDashboardsAsUrl = false
+    openDashboardsAsUrl = false,
+    mapLayerUrl,
+    mapLayerAttribution
   } = props;
+
+  const safeMapLayerUrl =
+    mapLayerUrl ?? 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+
+  const safeMapLayerAttribution =
+    mapLayerAttribution ??
+    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 
   const {
     openDashboard,
@@ -833,8 +842,8 @@ function LeafletRoot(props) {
         onZoomEnd={handleMapViewChange}
       >
         <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          attribution={safeMapLayerAttribution}
+          url={safeMapLayerUrl}
         />
         {weatherActive && renderWeatherLayer()}
         {renderRegions()}

--- a/visualizations/nr-mapbox/nr1.json
+++ b/visualizations/nr-mapbox/nr1.json
@@ -147,6 +147,18 @@
       "type": "string"
     },
     {
+      "name": "mapLayerUrl",
+      "title": "Map Tile Layer URL (leaflet only)",
+      "description": "URL template for the map tile layer (default: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png')",
+      "type": "string"
+    },
+    {
+      "name": "mapLayerAttribution",
+      "title": "Map Tile Layer Attribution (leaflet only)",
+      "description": "Attribution text/HTML shown for the map tile layer (default: '&copy; OpenStreetMap contributors')",
+      "type": "string"
+    },
+    {
       "name": "defaultMarkerColor",
       "title": "Default Marker Color",
       "description": "Fallback color for markers without threshold match (e.g., 'green', 'blue', '#FF5733')",


### PR DESCRIPTION
Allow overriding the Leaflet TileLayer's url and attribution via the new mapLayerUrl and mapLayerAttribution props, so users can point the map at a different tile provider instead of the hardcoded OpenStreetMap tiles. Both default to the previous OpenStreetMap values, so existing dashboards keep working unchanged.
